### PR TITLE
Docs and sample for populating Toolbox from manifests in fallback folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ Starting in Visual Studio 2019 version 16.3, the XAML designer supports two diff
 more recent surface isolation architecture. [This article](./documents/xaml-designer-extensibility-migration.md) explains the changes in detail. The [samples](./samples) folder contains code samples that demonstrate how to use XAML designer extensibility.
 
 ## Documents
-  - [XAML designer extensibility migration](./documents/xaml-designer-extensibility-migration.md)
+
+- [XAML designer extensibility migration](./documents/xaml-designer-extensibility-migration.md)
+- [Toolbox population](./documents/toolbox-population.md)
 
 ## Code Samples
-  - [CustomControlLibrary.WpfCore](./samples/CustomControlLibrary.WpfCore)
+
+- [CustomControlLibrary.WpfCore](./samples/CustomControlLibrary.WpfCore)
 
 ## Code of Conduct
+
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.microsoft.com.
@@ -23,4 +27,5 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## License
+
 These samples and templates are all licensed under the MIT license. See the LICENSE file in the root.

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -13,6 +13,8 @@ This approach requires registering with the Toolbox Controls Installer (TCI) in 
 
 If a NuGet package referenced by a XAML project contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest.
 
+You can try this by adding a reference to your own package or to [our WPF .NET Core sample package](#how-to-build-our-wpf-net-core-sample-package).
+
 ### Target Framework-specific Manifests
 
 In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the maniest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is no better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
@@ -42,16 +44,7 @@ If a NuGet package in a NuGet fallback folder contains a [tools\VisualStudioTool
 
 ### Getting started
 
-1. Create a NuGet package containing WPF .NET Core controls and a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls).
-
-   * You can either create your own package, or...
-   * Build our sample package by doing the following:
-
-     1. Clone this repo.
-     2. Open samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln.
-     3. Build the solution.
-     4. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or by running the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack
-
+1. Create a NuGet package containing WPF .NET Core controls and a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls). You could create your own package, or [build our sample package](#how-to-build-our-wpf-net-core-sample-package).
 2. Create a new directory somewhere on disk to serve as your NuGet fallback folder.
 3. Create a new text file with the extension .config (ex. MyFallbackFolder.config) in %ProgramFiles(x86)%\NuGet\Config.
 4. Add the following XML to the .config file, replacing c:\MyFallbackFolder with the actual path to your fallback folder.
@@ -78,3 +71,10 @@ If a NuGet package in a NuGet fallback folder contains a [tools\VisualStudioTool
 10. Wait for both the Toolbox and XAML designer to finish initializing.
 11. The Toolbox items defined in tools\VisualStudioToolsManifest.xml should appear in the Toolbox. If you're using our sample project, you should see a CustomControlLibrary.WpfCore tab in Toolbox containing a Toolbox item for the CustomButton control.
 12. Double-click one of the Toolbox items to add a control of that type to the XAML file.
+
+## How to build our WPF .NET Core sample package
+
+1. Clone [this repo](https://github.com/microsoft/xaml-designer-extensibility).
+2. Open samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln in Visual Studio.
+3. Build the solution.
+4. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or by running the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -34,7 +34,7 @@ If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-st
 ### Limitations of the fallback folder approach
 
 * It currently only supports WPF .NET Core packages and projects.
-* It only supports one manifest per package, in the root of the tools directory. [Manifests for specific Target Framework Monikers](#target-framework-specific-manifests) are not supported.
+* It currently only supports one manifest per package, in the root of the tools directory. [Manifests for specific Target Framework Monikers](#target-framework-specific-manifests) are not supported.
 
 ### Known issues in 16.7 Preview 2
 

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -32,7 +32,7 @@ If a NuGet package in a NuGet fallback folder contains a [tools\VisualStudioTool
 ### Limitations of the fallback folder approach
 
 * It currently only supports WPF .NET Core packages and projects.
-* It only supports one manifest per package, in the root of the tools directory. [Manifests for specific Target Framework Monikers](#markdown-header-target-framework-specific-manifests) are not supported.
+* It only supports one manifest per package, in the root of the tools directory. [Manifests for specific Target Framework Monikers](#target-framework-specific-manifests) are not supported.
 
 ### Known issues in 16.7 Preview 2
 

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -2,18 +2,20 @@
 
 ## Toolbox items from unreferenced assemblies (all supported versions of Visual Studio)
 
-This approach requires registering with the Toolbox Controls Installer (TCI) in the Windows registry. The TCI spec is available as a Word document [here](https://www.microsoft.com/en-us/download/details.aspx?id=35536) and explains how to register your assemblies. Once registered, your controls will be shown in the Toolbox for any compatible project, even projects that do not reference your assembly.
+This approach requires registering with the Toolbox Controls Installer (TCI) in the Windows registry. [The TCI spec](https://www.microsoft.com/en-us/download/details.aspx?id=35536) explains how to register your assemblies. Once registered, your controls will be shown in the Toolbox for any compatible project, even projects that do not reference your assembly.
 
 ### Limitations
 
-* This approach only works reliably for WPF .NET Framework. The controls in registered assemblies are enumerated via .NET Reflection. Reflecting over .NET Core assemblies within a .NET Framework process such as Visual Studio (devenv.exe) is unreliable.
+* This approach only works reliably for WPF .NET Framework assemblies. The controls in registered assemblies are enumerated via .NET Reflection which does not work reliably on .NET Core assemblies within a .NET Framework process such as Visual Studio.
 * Since registration requires modifying the registry, you need to provide an installer of some sort.
 
 ## Toolbox items from referenced NuGet packages (Visual Studio 15.0 and later)
 
-If a NuGet package contains a [VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls) in its tools directory, the Toolbox items listed in the manifest will be shown in the Toolbox for any project that references that package. More details on the manifest can be found .
+If a NuGet package referenced by a XAML project contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest.
 
-In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the maniest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is not better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
+### Target Framework-specific Manifests
+
+In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the maniest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is no better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
 
 Here's an example:
 
@@ -25,31 +27,32 @@ Here's an example:
 
 ## Toolbox items from unreferenced NuGet packages (Visual Studio 16.7 Preview 2 and later)
 
-If a NuGet package in a NuGet fallback folder contains a VisualStudioToolsManifest.xml in the root of its tools directory, the Toolbox items listed in the manifest will be shown in the Toolbox for any project that is compatible with the package, even projects that do not reference that package.
+If a NuGet package in a NuGet fallback folder contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest for any project that is compatible with the package, even projects that do not reference that package.
 
 ### Limitations of the fallback folder approach
 
 * It currently only supports WPF .NET Core packages and projects.
-* It only supports one manifest per package, in the root of the tools directory. Manifests for specific Target Framework Monikers described above are not supported.
+* It only supports one manifest per package, in the root of the tools directory. [Manifests for specific Target Framework Monikers](#markdown-header-target-framework-specific-manifests) are not supported.
 
 ### Known issues in 16.7 Preview 2
 
 * Custom icons are not supported yet.
+* Toolbox item names are indented.
 * After a package is referenced, Toolbox shows two copies of the Toolbox items.
 
 ### Getting started
 
-1. Create a NuGet package containing WPF .NET Core controls and a [VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls) in the tools directory.
+1. Create a NuGet package containing WPF .NET Core controls and a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls).
 
    * You can either create your own package, or...
    * Build our sample package by doing the following:
 
      1. Clone this repo.
      2. Open samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln.
-     3. Build solution.
-     4. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or alternatively run the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack
+     3. Build the solution.
+     4. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or by running the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack
 
-2. Create a directory somewhere on disk to serve as your NuGet fallback folder.
+2. Create a new directory somewhere on disk to serve as your NuGet fallback folder.
 3. Create a new text file with the extension .config (ex. MyFallbackFolder.config) in %ProgramFiles(x86)%\NuGet\Config.
 4. Add the following XML to the .config file, replacing c:\MyFallbackFolder with the actual path to your fallback folder.
 
@@ -63,7 +66,7 @@ If a NuGet package in a NuGet fallback folder contains a VisualStudioToolsManife
     ```
 
 5. Download nuget.exe as described [here](https://docs.microsoft.com/en-us/nuget/reference/nuget-exe-cli-reference).
-6. Expand the NuGet package into your fallback folder using the following command:
+6. Expand your NuGet package into your fallback folder using the following command:
 
     ```bat
     nuget.exe add <path to your nupkg> -Source <path to your fallback folder> -Expand

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -1,6 +1,14 @@
 # Toolbox population
 
-## Toolbox items from unreferenced assemblies (all supported versions of Visual Studio)
+There are several ways to get your XAML controls to appear in Visual Studio's Toolbox pane. Some of the approaches are outlined below. 
+
+| Population mechanism                                                           | Supported Frameworks | Supported Visual Studio Versions       |
+| :----------------------------------------------------------------------------- | :------------------- | :------------------------------------- |
+| [Unreferenced assemblies](#toolbox-items-from-unreferenced-assemblies)         | WPF .NET Framework   | All supported versions                 |
+| [Referenced NuGet packages](#toolbox-items-from-referenced-nuget-packages)     | All XAML frameworks  | Visual Studio 15.0 and later           |
+| [Unreferenced NuGet packages](#toolbox-items-from-unreferenced-nuget-packages) | WPF .NET Core        | Visual Studio 16.7 Preview 2 and later |
+
+## Toolbox items from unreferenced assemblies
 
 This approach requires registering with the Toolbox Controls Installer (TCI) in the Windows registry. [The TCI specification](https://www.microsoft.com/en-us/download/details.aspx?id=35536) explains how to register your assemblies. Once registered, your controls will be shown in the Toolbox for any compatible project, even projects that do not reference your assembly.
 
@@ -9,7 +17,7 @@ This approach requires registering with the Toolbox Controls Installer (TCI) in 
 * This approach is only supported for WPF .NET Framework assemblies.
 * Since registration requires modifying the registry, you need to provide an installer of some sort.
 
-## Toolbox items from referenced NuGet packages (Visual Studio 15.0 and later)
+## Toolbox items from referenced NuGet packages
 
 If a NuGet package referenced by a XAML project contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest.
 
@@ -27,7 +35,7 @@ Here's an example:
 | \tools\netcoreapp31\VisualStudioToolsManifest.xml | .NET Core >= 3.1                                            |
 | \tools\VisualStudioToolsManifest.xml              | .NET Framework < 4.7, .NET Core < 3.1, and other frameworks |
 
-## Toolbox items from unreferenced NuGet packages (Visual Studio 16.7 Preview 2 and later)
+## Toolbox items from unreferenced NuGet packages
 
 If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-started) section below) contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest for any project that is compatible with the package, even projects that do not reference that package.
 

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -29,11 +29,11 @@ In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStud
 
 Here's an example:
 
-| File path                                         | Will be used for projects targeting...                      |
-| :------------------------------------------------ | :---------------------------------------------------------- |
-| \tools\net47\VisualStudioToolsManifest.xml        | .NET Framework >= 4.7                                       |
-| \tools\netcoreapp31\VisualStudioToolsManifest.xml | .NET Core >= 3.1                                            |
-| \tools\VisualStudioToolsManifest.xml              | .NET Framework < 4.7, .NET Core < 3.1, and other frameworks |
+| File path                                        | Will be used for projects targeting...                      |
+| :----------------------------------------------- | :---------------------------------------------------------- |
+| tools\net47\VisualStudioToolsManifest.xml        | .NET Framework >= 4.7                                       |
+| tools\netcoreapp31\VisualStudioToolsManifest.xml | .NET Core >= 3.1                                            |
+| tools\VisualStudioToolsManifest.xml              | .NET Framework < 4.7, .NET Core < 3.1, and other frameworks |
 
 ## Toolbox items from unreferenced NuGet packages
 

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -1,0 +1,77 @@
+# Toolbox population
+
+## Toolbox items from unreferenced assemblies (all supported versions of Visual Studio)
+
+This approach requires registering with the Toolbox Controls Installer (TCI) in the Windows registry. The TCI spec is available as a Word document [here](https://www.microsoft.com/en-us/download/details.aspx?id=35536) and explains how to register your assemblies. Once registered, your controls will be shown in the Toolbox for any compatible project, even projects that do not reference your assembly.
+
+### Limitations
+
+* This approach only works reliably for WPF .NET Framework. The controls in registered assemblies are enumerated via .NET Reflection. Reflecting over .NET Core assemblies within a .NET Framework process such as Visual Studio (devenv.exe) is unreliable.
+* Since registration requires modifying the registry, you need to provide an installer of some sort.
+
+## Toolbox items from referenced NuGet packages (Visual Studio 15.0 and later)
+
+If a NuGet package contains a [VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls) in its tools directory, the Toolbox items listed in the manifest will be shown in the Toolbox for any project that references that package. More details on the manifest can be found .
+
+In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the maniest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is not better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
+
+Here's an example:
+
+| File path                                         | Will be used for projects targetting...                     |
+| :------------------------------------------------ | :---------------------------------------------------------- |
+| \tools\net47\VisualStudioToolsManifest.xml        | .NET Framework >= 4.7                                       |
+| \tools\netcoreapp31\VisualStudioToolsManifest.xml | .NET Core >= 3.1                                            |
+| \tools\VisualStudioToolsManifest.xml              | .NET Framework < 4.7, .NET Core < 3.1, and other frameworks |
+
+## Toolbox items from unreferenced NuGet packages (Visual Studio 16.7 Preview 2 and later)
+
+If a NuGet package in a NuGet fallback folder contains a VisualStudioToolsManifest.xml in the root of its tools directory, the Toolbox items listed in the manifest will be shown in the Toolbox for any project that is compatible with the package, even projects that do not reference that package.
+
+### Limitations of the fallback folder approach
+
+* It currently only supports WPF .NET Core packages and projects.
+* It only supports one manifest per package, in the root of the tools directory. Manifests for specific Target Framework Monikers described above are not supported.
+
+### Known issues in 16.7 Preview 2
+
+* Custom icons are not supported yet.
+* After a package is referenced, Toolbox shows two copies of the Toolbox items.
+
+### Getting started
+
+1. Create a NuGet package containing WPF .NET Core controls and a [VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls) in the tools directory.
+
+   * You can either create your own package, or...
+   * Build our sample package by doing the following:
+
+     1. Clone this repo.
+     2. Open samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln.
+     3. Build solution.
+     4. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or alternatively run the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack
+
+2. Create a directory somewhere on disk to serve as your NuGet fallback folder.
+3. Create a new text file with the extension .config (ex. MyFallbackFolder.config) in %ProgramFiles(x86)%\NuGet\Config.
+4. Add the following XML to the .config file, replacing c:\MyFallbackFolder with the actual path to your fallback folder.
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <fallbackPackageFolders>
+        <add key="FallbackFolderTest" value="c:\MyFallbackFolder" />
+      </fallbackPackageFolders>
+    </configuration>
+    ```
+
+5. Download nuget.exe as described [here](https://docs.microsoft.com/en-us/nuget/reference/nuget-exe-cli-reference).
+6. Expand the NuGet package into your fallback folder using the following command:
+
+    ```bat
+    nuget.exe add <path to your nupkg> -Source <path to your fallback folder> -Expand
+    ```
+
+7. Launch Visual Studio 16.7 Preview 2 or later.
+8. Create a new WPF .NET Core project.
+9. Open the Toolbox pane
+10. Wait for both the Toolbox and XAML designer to finish initializing.
+11. The Toolbox items defined in tools\VisualStudioToolsManifest.xml should appear in the Toolbox. If you're using our sample project, you should see a CustomControlLibrary.WpfCore tab in Toolbox containing a Toolbox item for the CustomButton control.
+12. Double-click one of the Toolbox items to add a control of that type to the XAML file.

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -6,7 +6,7 @@ This approach requires registering with the Toolbox Controls Installer (TCI) in 
 
 ### Limitations
 
-* This approach only works reliably for WPF .NET Framework assemblies. The controls in registered assemblies are enumerated via .NET Reflection which does not work reliably on .NET Core assemblies within a .NET Framework process such as Visual Studio.
+* This approach is only supported for WPF .NET Framework assemblies.
 * Since registration requires modifying the registry, you need to provide an installer of some sort.
 
 ## Toolbox items from referenced NuGet packages (Visual Studio 15.0 and later)
@@ -17,11 +17,11 @@ You can try this by adding a reference to your own package or to [our WPF .NET C
 
 ### Target Framework-specific Manifests
 
-In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the maniest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is no better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
+In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the manifest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is no better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
 
 Here's an example:
 
-| File path                                         | Will be used for projects targetting...                     |
+| File path                                         | Will be used for projects targeting...                      |
 | :------------------------------------------------ | :---------------------------------------------------------- |
 | \tools\net47\VisualStudioToolsManifest.xml        | .NET Framework >= 4.7                                       |
 | \tools\netcoreapp31\VisualStudioToolsManifest.xml | .NET Core >= 3.1                                            |
@@ -29,7 +29,7 @@ Here's an example:
 
 ## Toolbox items from unreferenced NuGet packages (Visual Studio 16.7 Preview 2 and later)
 
-If a NuGet package in a NuGet fallback folder contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest for any project that is compatible with the package, even projects that do not reference that package.
+If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-started) section below) contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest for any project that is compatible with the package, even projects that do not reference that package.
 
 ### Limitations of the fallback folder approach
 
@@ -70,7 +70,7 @@ If a NuGet package in a NuGet fallback folder contains a [tools\VisualStudioTool
 9. Open the Toolbox pane
 10. Wait for both the Toolbox and XAML designer to finish initializing.
 11. The Toolbox items defined in tools\VisualStudioToolsManifest.xml should appear in the Toolbox. If you're using our sample project, you should see a CustomControlLibrary.WpfCore tab in Toolbox containing a Toolbox item for the CustomButton control.
-12. Double-click one of the Toolbox items to add a control of that type to the XAML file.
+12. Double-click one of the Toolbox items to add a control of that type to the XAML file and add a package reference for the NuGet package to the project.
 
 ## How to build our WPF .NET Core sample package
 

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -2,7 +2,7 @@
 
 ## Toolbox items from unreferenced assemblies (all supported versions of Visual Studio)
 
-This approach requires registering with the Toolbox Controls Installer (TCI) in the Windows registry. [The TCI spec](https://www.microsoft.com/en-us/download/details.aspx?id=35536) explains how to register your assemblies. Once registered, your controls will be shown in the Toolbox for any compatible project, even projects that do not reference your assembly.
+This approach requires registering with the Toolbox Controls Installer (TCI) in the Windows registry. [The TCI specification](https://www.microsoft.com/en-us/download/details.aspx?id=35536) explains how to register your assemblies. Once registered, your controls will be shown in the Toolbox for any compatible project, even projects that do not reference your assembly.
 
 ### Limitations
 

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -83,6 +83,6 @@ If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-st
 ## How to build our WPF .NET Core sample package
 
 1. Clone [this repo](https://github.com/microsoft/xaml-designer-extensibility).
-2. Open samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln in Visual Studio.
+2. Open [...\samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln](../samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.sln) in Visual Studio.
 3. Build the solution.
 4. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or by running the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack

--- a/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
+++ b/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
@@ -87,7 +87,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.DesignTools.Extensibility">
-      <Version>16.6.30107.105</Version>
+      <Version>16.4.29519.181</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
+++ b/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
@@ -31,8 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.DesignTools.Extensibility" />
-    <Reference Include="Microsoft.VisualStudio.DesignTools.Interaction" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
@@ -86,6 +84,11 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.DesignTools.Extensibility">
+      <Version>16.6.30107.105</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
+++ b/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.DesignTools/CustomControlLibrary.WpfCore.DesignTools.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.DesignTools.Extensibility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
-    <Reference Include="Microsoft.VisualStudio.DesignTools.Interaction, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86" />
+    <Reference Include="Microsoft.VisualStudio.DesignTools.Extensibility" />
+    <Reference Include="Microsoft.VisualStudio.DesignTools.Interaction" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />

--- a/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.csproj
+++ b/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.csproj
@@ -5,4 +5,26 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <PackageId>CustomControlLibrary.WpfCore</PackageId>
+    <Description>CustomControlLibrary.WpfCore</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageFile Include="VisualStudioToolsManifest.xml">
+      <Kind>Tools</Kind>
+    </PackageFile>
+    <PackageFile Include="$(OutputPath)\CustomControlLibrary.WpfCore.DesignTools.dll">
+      <Kind>Lib</Kind>
+      <TargetPath>Design\CustomControlLibrary.WpfCore.DesignTools.dll</TargetPath>
+    </PackageFile>
+  </ItemGroup>
+
 </Project>

--- a/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore/VisualStudioToolsManifest.xml
+++ b/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore/VisualStudioToolsManifest.xml
@@ -1,0 +1,7 @@
+﻿<FileList>
+  <File Reference="CustomControlLibrary.WpfCore.dll">
+    <ToolboxItems VSCategory="CustomControlLibrary.WpfCore" BlendCategory="CustomControlLibrary.WpfCore">
+      <Item Type="CustomControlLibrary.WpfCore.CustomButton" />
+    </ToolboxItems>
+  </File>
+</FileList>


### PR DESCRIPTION
1. Added toolbox-population.md with documentation on several common ways to populate the Toolbox with XAML controls. It's linked from the README.md. I'll update the doc in the future to talk about ProjectReference auto-pop, UWP extension SDKs, Toolbox icons, etc. This is just a start.
2. Added NuGetizer 3000 support to CustomControlLibrary.WpfCore.csproj. The resulting nupkg contains the control assembly, design DLL, and a new VisualStudioToolsManifest.xml.
3. The sample project didn't build in 16.7 because the assembly version on the Extensibility and Interaction DLLs is 16.5.0.0 but the references requested 16.0.0.0, so I changed the project to reference these DLLs by name instead of strong name. Is this the correct approach?