### PR TITLE
Add support for UIFramework attribute

### DIFF
--- a/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore/VisualStudioToolsManifest.xml
+++ b/samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore/VisualStudioToolsManifest.xml
@@ -1,6 +1,6 @@
 ﻿<FileList>
   <File Reference="CustomControlLibrary.WpfCore.dll">
-    <ToolboxItems VSCategory="CustomControlLibrary.WpfCore" BlendCategory="CustomControlLibrary.WpfCore">
+    <ToolboxItems UIFramework="WPF" VSCategory="CustomControlLibrary.WpfCore" BlendCategory="CustomControlLibrary.WpfCore">
       <Item Type="CustomControlLibrary.WpfCore.CustomButton" />
     </ToolboxItems>
   </File>


### PR DESCRIPTION
Introducing a new UIFramework attribute for ToolboxItems and/or Items in the manifest solves problem of distinguish between the platforms like, WPF,UWP, WinForms etc.