### PR TITLE
Update Toolbox documentation based on changes in 16.8

### DIFF
--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -23,18 +23,6 @@ If a NuGet package referenced by a XAML project contains a [tools\VisualStudioTo
 
 You can try this by adding a reference to your own package or to [our WPF .NET Core sample package](#how-to-build-our-wpf-net-core-sample-package).
 
-### Target Framework-specific manifests in referenced NuGet packages
-
-In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the manifest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is no better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
-
-Here's an example:
-
-| File path                                        | Will be used for projects targeting...                      |
-| :----------------------------------------------- | :---------------------------------------------------------- |
-| tools\net47\VisualStudioToolsManifest.xml        | .NET Framework >= 4.7                                       |
-| tools\netcoreapp31\VisualStudioToolsManifest.xml | .NET Core >= 3.1                                            |
-| tools\VisualStudioToolsManifest.xml              | .NET Framework < 4.7, .NET Core < 3.1, and other frameworks |
-
 ## Toolbox items from unreferenced NuGet packages
 
 If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-started) section below) contains a [tools\VisualStudioToolsManifest.xml file](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls), Toolbox will show the Toolbox items listed in the manifest for any project that is compatible with the package, even projects that do not reference that package.
@@ -75,13 +63,23 @@ If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-st
 1. The Toolbox items defined in tools\VisualStudioToolsManifest.xml should appear in the Toolbox. If you're using our sample project, you should see a CustomControlLibrary.WpfCore tab in Toolbox containing a Toolbox item for the CustomButton control.
 1. Double-click one of the Toolbox items to add a control of that type to the XAML file and add a package reference for the NuGet package to the project.
 
+## TargetFramework-specific manifests
+
+Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the manifest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is no better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
+
+For referenced NuGet packages, this feature requires Visual Studio 16.6 or later. For unreferenced NuGet packages, this feature requires Visual Studio 16.8 Preview 3 or later.  
+
+Here's an example:
+
+| File path                                        | Will be used for projects targeting...                      |
+| :----------------------------------------------- | :---------------------------------------------------------- |
+| tools\net47\VisualStudioToolsManifest.xml        | .NET Framework >= 4.7                                       |
+| tools\netcoreapp31\VisualStudioToolsManifest.xml | .NET Core >= 3.1                                            |
+| tools\VisualStudioToolsManifest.xml              | .NET Framework < 4.7, .NET Core < 3.1, and other frameworks |
+
 ## How to build our WPF .NET Core sample package
 
 1. Clone [this repo](https://github.com/microsoft/xaml-designer-extensibility).
 1. Open [...\samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln](../samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.sln) in Visual Studio.
 1. Build the solution.
 1. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or by running the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack
-
-### Target Framework-specific manifests in unreferenced NuGet packages
-
-In Visual Studio 16.8 Preview 3 and later, fallback folder-based Toolbox population supports multiple VisualStudioToolsManifest.xml files per package. The behavior in this scenario is described [above](#target-framework-specific-manifests-in-referenced-nuget-packages).

--- a/documents/toolbox-population.md
+++ b/documents/toolbox-population.md
@@ -1,6 +1,6 @@
 # Toolbox population
 
-There are several ways to get your XAML controls to appear in Visual Studio's Toolbox pane. Some of the approaches are outlined below. 
+There are several ways to get your XAML controls to appear in Visual Studio's Toolbox pane. Some of the approaches are outlined below.
 
 | Population mechanism                                                           | Supported Frameworks | Supported Visual Studio Versions       |
 | :----------------------------------------------------------------------------- | :------------------- | :------------------------------------- |
@@ -23,7 +23,7 @@ If a NuGet package referenced by a XAML project contains a [tools\VisualStudioTo
 
 You can try this by adding a reference to your own package or to [our WPF .NET Core sample package](#how-to-build-our-wpf-net-core-sample-package).
 
-### Target Framework-specific Manifests
+### Target Framework-specific manifests in referenced NuGet packages
 
 In Visual Studio 16.6 and later, Toolbox population supports multiple VisualStudioToolsManifest.xml files per package -- the manifest in the tools root plus additional manifests for specific Target Framework Monikers (TFMs) in subdirectories of tools. The Toolbox will show the items from the manifest that best matches the target framework of the current project, falling back to the manifest in the tools root if there is no better match. The manifest in the tools root is also required for compatibility with older versions of Visual Studio.
 
@@ -42,7 +42,6 @@ If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-st
 ### Limitations of the fallback folder approach
 
 * It currently only supports WPF .NET Core packages and projects.
-* It currently only supports one manifest per package, in the root of the tools directory. [Manifests for specific Target Framework Monikers](#target-framework-specific-manifests) are not supported.
 
 ### Getting started
 
@@ -82,3 +81,7 @@ If a NuGet package in a NuGet fallback folder (see [Getting Started](#getting-st
 1. Open [...\samples\CustomControlLibrary.WpfCore\CustomControlLibrary.WpfCore.sln](../samples/CustomControlLibrary.WpfCore/CustomControlLibrary.WpfCore.sln) in Visual Studio.
 1. Build the solution.
 1. Generate the package (bin\Debug\CustomControlLibrary.WpfCore.1.0.0.nupkg) by right-clicking on the CustomControlLibrary.WpfCore project in Solution Explorer and selecting Pack, or by running the following command from the directory containing CustomControlLibrary.WpfCore.csproj: msbuild /t:Pack
+
+### Target Framework-specific manifests in unreferenced NuGet packages
+
+In Visual Studio 16.8 Preview 3 and later, fallback folder-based Toolbox population supports multiple VisualStudioToolsManifest.xml files per package. The behavior in this scenario is described [above](#target-framework-specific-manifests-in-referenced-nuget-packages).


### PR DESCRIPTION
Removed bullet point about TFM-specific manifests not being supported

Moved TFM-specific manifest documentation out of the "referenced packages" section and added details on when it became supported for the "unreferenced packages" scenario.