### PR TITLE
Add documentation for Suggested Actions on Non-Visual Elements

### DIFF
--- a/documents/xaml-suggested-actions/xaml-designer-suggested-actions-extensibility-nonvisualelements.md
+++ b/documents/xaml-suggested-actions/xaml-designer-suggested-actions-extensibility-nonvisualelements.md
@@ -1,4 +1,7 @@
 ## Suggested Actions For Non-Visual Elements
+
+In Visual Studio 2019 16.9 Preview 1, we added support for displaying Suggested Actions on non-visual elements.
+
 To display Suggested Actions for a non-visual element, the designer needs to know where to place the Suggested Actions adorner. You can create a custom `ViewItemProvider` to provide this information and add it to the non-visual element alongside your `SuggestedActionProvider`.
 
 A `ViewItemProvider` implements one method, `GetViewItem`, which receives the non-visual element as a `ModelItem` and returns a `ViewItem`. This `ViewItem` describes the bounds the designer should use for the non-visual element when placing the Suggested Actions adorner.
@@ -12,7 +15,7 @@ public class MyNonVisualControlViewItemProvider : ViewItemProvider
     {
         // Find the first visual parent of the non-visual view-item.
         ModelItem parent = modelItem.Parent;
-        while(!parent.View.IsVisible)
+        while (!parent.View.IsVisible)
         {
             parent = parent.Parent;
         }

--- a/documents/xaml-suggested-actions/xaml-designer-suggested-actions-extensibility-nonvisualelements.md
+++ b/documents/xaml-suggested-actions/xaml-designer-suggested-actions-extensibility-nonvisualelements.md
@@ -1,0 +1,23 @@
+## Suggested Actions For Non-Visual Elements
+To display Suggested Actions for a non-visual element, the designer needs to know where to place the Suggested Actions adorner. You can create a custom `ViewItemProvider` to provide this information and add it to the non-visual element alongside your `SuggestedActionProvider`.
+
+A `ViewItemProvider` implements one method, `GetViewItem`, which receives the non-visual element as a `ModelItem` and returns a `ViewItem`. This `ViewItem` describes the bounds the designer should use for the non-visual element when placing the Suggested Actions adorner.
+
+### Example
+This sample `ViewItemProvider` will lookup  the first visual parent for a non-visual control, then return that parent's view as the `ViewItem`. The designer will then show the Suggested Actions adorner at the corner of the parent's bounds.
+```CS
+public class MyNonVisualControlViewItemProvider : ViewItemProvider
+{
+    public override ViewItem GetViewItem(ModelItem modelItem)
+    {
+        // Find the first visual parent of the non-visual view-item.
+        ModelItem parent = modelItem.Parent;
+        while(!parent.View.IsVisible)
+        {
+            parent = parent.Parent;
+        }
+
+        return parent.View;
+    }
+}
+```


### PR DESCRIPTION
This adds a page for the missing documentation on non-visual elements. The link to these docs was added in a previous change, but the actual file was missing. Fixes #36.