### PR TITLE
Fix Syntax in Inherited Controls Code Example

### DIFF
--- a/documents/xaml-suggested-actions/xaml-designer-suggested-actions-extensibility.md
+++ b/documents/xaml-suggested-actions/xaml-designer-suggested-actions-extensibility.md
@@ -61,7 +61,7 @@ public class ExampleSimpleButton : ExampleButton { }
 ```CS
 public class ExampleSimpleButtonSuggestedActionProvider : ExampleButtonSuggestedActionProvider
 {
-    public static ActionToken Token_Property_CustomProp = ExampleButtonSuggestedActionProviderToken_Last + 1;
+    public static ActionToken Token_Property_CustomProp = ExampleButtonSuggestedActionProvider.Token_Last + 1;
     public new static ActionToken Token_Last = new ActionToken(0x2FFF);
     public override void Initialize()
     {


### PR DESCRIPTION
Missing dot between ExampleButtonSuggestedActionProvider and Token_Last